### PR TITLE
Fix identifier for the Open Funder Registry

### DIFF
--- a/schematrons/1.0/funding-errors.sch
+++ b/schematrons/1.0/funding-errors.sch
@@ -55,8 +55,8 @@
     </rule>
     
     <rule context="article[number(replace(@dtd-version,'[^\d\.]','')) ge 1.2]//funding-group//institution-id[@vocab='open-funder-registry']">
-        <assert test="@vocab-identifier='10.13039/open-funder-registry'">
-            &lt;institution vocab="open-funder-registry"> in JATS <value-of select="ancestor::article/@dtd-version"/> must have an @vocab-identifier="10.13039/open-funder-registry". 
+        <assert test="@vocab-identifier='10.13039/open_funder_registry'">
+            &lt;institution vocab="open-funder-registry"> in JATS <value-of select="ancestor::article/@dtd-version"/> must have an @vocab-identifier="10.13039/open_funder_registry". 
         </assert>
         
         <assert test="@institution-id-type='doi'">


### PR DESCRIPTION
The correct DOI for the Open Funder Registry is [`10.13039/open_funder_registry`](https://doi.org/10.13039/open_funder_registry) rather than [`10.13039/open-funder-registry`](https://doi.org/10.13039/open-funder-registry) (this appears to be a mistake in [the funding recommendation](https://jats4r.org/funding)).