### PR TITLE
Permissions2

### DIFF
--- a/schematrons/1.0/permissions-errors.sch
+++ b/schematrons/1.0/permissions-errors.sch
@@ -58,11 +58,26 @@
   
   <rule context="license">
     <!-- if both @xlink:href and ali:license_ref are used, they must match exactly -->
-    <report test="@xlink:href and ali:license_ref and
-      string(@xlink:href) != string(ali:license_ref)" role="error">
+    <report test="@xlink:href and child::node()[local-name()='license_ref'] and
+      string(@xlink:href) != string(child::node()[local-name()='license_ref'])" role="error">
       If both @xlink:href and &lt;ali:license_ref> are used to specify the licence
       URI of an article, their contents must match exactly.
     </report>
+    <report test="count(child::node()[local-name()='license_ref']) > 1 and child::node()[local-name()='license_ref'][not(@start_date)]" role="error">
+      If multiple &lt;ali:license_ref&gt; elements are tagged they must have @start_date to indicate when each license is applicable.
+    </report>
+  </rule>
+  
+  <rule context="child::node()[local-name()='free_to_read']">
+    <report test="@start_date and @end_date and @start_date gt @end_date" role="error">
+      @end_date must be later than @start_date on &lt;ali:free_to_read&gt;.
+    </report>
+  </rule>
+  
+  <rule context="@start_date|@end_date">
+    <assert test="(matches(., '^\d{4}-\d{2}-\d{2}$') and (. castable as xs:date))" role="error">
+      @<value-of select="name(.)"/> must contain valid dates in ISO-8601 YYYY-MM-DD format.
+    </assert>
   </rule>
   
 </pattern>

--- a/schematrons/1.0/permissions-warnings.sch
+++ b/schematrons/1.0/permissions-warnings.sch
@@ -27,8 +27,8 @@
 
   <rule context="license">
     <let name="jurisdictions" value="'(am|at|au|az|br|ca|ch|cl|cn|cr|cz|de|ec|ee|eg|es|fr|ge|gr|gt|hk|hr|ie|igo|it|lu|nl|no|nz|ph|pl|pr|pt|ro|rs|sg|th|tw|ug|us|ve|vn|za)'"/>
-    <let name="p1" value="'https://creativecommons\.org/licenses/by(-sa|-nd|-nc|nc-sa|nc-nd)?/4\.0/'"/>
-    <let name="p2" value="concat('https://creativecommons\.org/licenses/by(-sa|-nd|-nc|nc-sa|nc-nd)?/(1|2|3)\.\d(/', $jurisdictions, ')?/')"/>
+    <let name="p1" value="'https://creativecommons\.org/licenses/by(-sa|-nd|-nc|-nc-sa|-nc-nd)?/4\.0/'"/>
+    <let name="p2" value="concat('https://creativecommons\.org/licenses/by(-sa|-nd|-nc|-nc-sa|-nc-nd)?/(1|2|3)\.\d(/', $jurisdictions, ')?/')"/>
     <let name="p3" value="'https://creativecommons\.org/publicdomain/(zero|mark)/1\.0/'"/>
     <let name="li_check" value="if (child::node()[local-name()='license_ref']) then child::node()[local-name()='license_ref'] else @xlink:href"/>
     

--- a/schematrons/1.0/permissions-warnings.sch
+++ b/schematrons/1.0/permissions-warnings.sch
@@ -26,6 +26,15 @@
          xmlns:j4r="http://jats4r.org/ns">
 
   <rule context="license">
+    <let name="jurisdictions" value="'(am|at|au|az|br|ca|ch|cl|cn|cr|cz|de|ec|ee|eg|es|fr|ge|gr|gt|hk|hr|ie|igo|it|lu|nl|no|nz|ph|pl|pr|pt|ro|rs|sg|th|tw|ug|us|ve|vn|za)'"/>
+    <let name="p1" value="'https://creativecommons\.org/licenses/by(-sa|-nd|-nc|nc-sa|nc-nd)?/4\.0/'"/>
+    <let name="p2" value="concat('https://creativecommons\.org/licenses/by(-sa|-nd|-nc|nc-sa|nc-nd)?/(1|2|3)\.\d(/', $jurisdictions, ')?/')"/>
+    <let name="p3" value="'https://creativecommons\.org/publicdomain/(zero|mark)/1\.0/'"/>
+    <let name="li_check" value="if (child::node()[local-name()='license_ref']) then child::node()[local-name()='license_ref'] else @xlink:href"/>
+    
+    <report test="contains($li_check, 'creativecommons.org') and not(matches($li_check, $p1) or matches($li_check, $p2) or matches($li_check, $p3))" role="warning">
+      Creative Commons licenses should follow the recommended patterns. <value-of select="$li_check"/> is not a best practices pattern for a Creative Commons URL. Check that it uses https and a trailing slash.
+    </report>
 
     <!-- If license/@xlink:href exists, it must not be empty -->
     <report test="@xlink:href and normalize-space(@xlink:href) = ''" role="warning"> 
@@ -66,7 +75,19 @@
     </report>
 
   </rule>
-
-
+  
+  <rule context="license-p">
+    <let name="li_check" value="if (parent::license/child::node()[local-name()='license_ref']) then parent::license/child::node()[local-name()='license_ref'] else parent::license/@xlink:href"/>
+    <report test="ext-link and ext-link/@xlink:href != $li_check" role="warning">URI in license-p (<value-of select="ext-link/@xlink:href"/>) does not match canonical license URI (<value-of select="$li_check"/>).</report>
+  </rule>
+  
+  <rule context="copyright-statement">
+    <report test="parent::permissions/copyright-year and not(contains(., parent::permissions/copyright-year))" role="warning">
+      The contents of &lt;copyright-statement&gt; should not conflict with &lt;copyright-year&gt;.
+    </report>
+    <report test="parent::permissions/copyright-holder and not(contains(lower-case(.), lower-case(parent::permissions/copyright-holder)))" role="warning">
+      The contents of &lt;copyright-statement&gt; should not conflict with &lt;copyright-holder&gt;.
+    </report>
+  </rule>
 
 </pattern>


### PR DESCRIPTION
This recommendation is currently in the public review period: https://docs.google.com/document/d/17o8Op-fX3eLk-oNdSTKOU1ntbBzR-j09Q5sqUzNwNqk/edit

Note: the DTD version check function (j4r:jats-version-later-1d2) did not seem to work, nor did any xpath using ali elements including the namespace (i.e. referring to "ali:license_ref" rather than "child::node()[local-name()='license_ref']").